### PR TITLE
Switch Crashlytics to using the same account we use for android.

### DIFF
--- a/DanceDeets.xcodeproj/project.pbxproj
+++ b/DanceDeets.xcodeproj/project.pbxproj
@@ -472,7 +472,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "./Fabric.framework/run 3500be0723f399c8c334c37b889dfab6cb5903a2 73ec5c4c633dff26e68168857b87f035ca37e2882ac14ee7b97c45ece2619ec8";
+			shellScript = "./Fabric.framework/run f827a34a7ab66071f1fc473cdfa00f94403b241b 5ca03b8142243c84d2a6de3bd37dfebc06f7b5b986ece6a61d6474b3b7d6602b";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/DanceDeets/Info.plist
+++ b/DanceDeets/Info.plist
@@ -32,7 +32,7 @@
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>
-		<string>3500be0723f399c8c334c37b889dfab6cb5903a2</string>
+		<string>f827a34a7ab66071f1fc473cdfa00f94403b241b</string>
 		<key>Kits</key>
 		<array>
 			<dict>


### PR DESCRIPTION
Switch to using the same Crashlytics account that we're using for Android. Android sets up two accounts (debug and live) for bucketing crashes, not sure if that's something that's needed for iOS or not, though.